### PR TITLE
fix: overwrites agenda files

### DIFF
--- a/org-outlook.el
+++ b/org-outlook.el
@@ -330,7 +330,7 @@ Returns the authorization code on success."
 		  (when data
 		    (message "Created event")))))))
 
-(if (listp 'org-agenda-files)
+(if (listp org-agenda-files)
     (add-to-list 'org-agenda-files org-outlook-file)
   (setq org-agenda-files (list org-outlook-file)))
 


### PR DESCRIPTION
A typo made it so that the agenda files were always overwritten.